### PR TITLE
FIX: Prevent a Null check operator used on a null value error

### DIFF
--- a/lib/src/protocol/messages.dart
+++ b/lib/src/protocol/messages.dart
@@ -99,7 +99,7 @@ class MessageSet {
     var builder = KafkaBytesBuilder();
     builder.addInt8(0); // magicByte
     builder.addInt8(message.attributes!.toInt());
-    builder.addBytes(message.key!);
+    builder.addBytes(message.key);
     builder.addBytes(message.value);
 
     var data = builder.takeBytes();


### PR DESCRIPTION
if a `Message` object does not specify a `key`, a `Null check operator used on a null value error` is thrown.

The `Message` constructor indicates that `key` is optional.

When preparing to send the Message, instead of coercing `key` with `!`, we allow it to be null; the null key value is harmless when sent to Kafka.

This change permits the main usage example to run; the sample flutter code specifies `key`, so it would not have received this error.